### PR TITLE
parisc: bound the LSR poll in parisc_serial_out() to avoid a firmware deadlock

### DIFF
--- a/src/parisc/parisc.c
+++ b/src/parisc/parisc.c
@@ -1117,6 +1117,16 @@ static unsigned long parisc_serial_in(char *c, unsigned long maxchars)
     return count;
 }
 
+/* A guest OS may transiently unmap or resize the console UART's PCI BAR
+ * (e.g. the standard 0xffffffff BAR-sizing probe issued via PDC_PAT_IO).
+ * The console MMIO address cached in dev->pci_addr is not re-read, so a
+ * print in that window polls an unbacked address: reads return 0, the
+ * "(lsr & 0x60) == 0x60" test below can never pass, and an unbounded
+ * loop would spin forever INSIDE the PDC call -- the guest never runs
+ * again to restore the BAR.  Bound the poll: a transiently-unmapped
+ * console costs a few dropped characters instead of a machine hang. */
+#define SERIAL_OUT_POLL_LIMIT 10000
+
 static void parisc_serial_out(char c)
 {
     portaddr_t addr = PAGE0->mem_cons.hpa;
@@ -1148,6 +1158,7 @@ static void parisc_serial_out(char c)
     if (c == '\n')
         parisc_serial_out('\r');
 
+    unsigned int poll_count = 0;
     for (;;) {
         u8 lsr = inb(F_EXTEND(addr+SEROFF_LSR));
         if ((lsr & 0x60) == 0x60) {
@@ -1155,6 +1166,8 @@ static void parisc_serial_out(char c)
             outb(c, F_EXTEND(addr+SEROFF_DATA));
             break;
         }
+        if (++poll_count >= SERIAL_OUT_POLL_LIMIT)
+            break;      /* transiently unmapped BAR: drop char, don't hang */
     }
 }
 


### PR DESCRIPTION
Context: we are booting MPE/iX 7.5 (HP e3000 A400-class) on qemu-hppa + seabios-hppa, modeling the A400 against measurements from a real A400. This fix is general, not MPE-specific.

**Problem:** `parisc_serial_out()`'s LSR ready-poll is an unbounded `for(;;)`, against a console MMIO address cached once at init (`find_serial_pci_card()` -> `dev->pci_addr`) and never re-read. If the guest OS performs the standard PCI BAR-sizing probe (write 0xffffffff, read, restore) on the console function — legal PCI that any guest may issue — QEMU's 32-bit wrap guard in `pci_bar_address()` unmaps the BAR between probe and restore. A firmware print in that window (e.g. a PDC-time debug print) polls an unbacked address; reads return 0, `(lsr & 0x60) == 0x60` can never pass, and the firmware spins forever *inside the PDC call* — the guest never runs again to restore the BAR. Deadlock.

**Measured:** byte-identically reproducible on our A400 rig; the fatal probe write is the literal last config cycle of the trace (`pci_cfg_write diva-gsp 00:04.1 @0x10 <- 0xffffffff`) followed by 4,114,337 rejected reads from a single print. With the bound in place the same boot survives the probe (0 rejected reads) and proceeds — MPE/iX now configures its console and runs into Genesis.

**Fix:** bound the poll (10,000 iterations), drop the character on expiry. A transiently-unmapped console costs a few dropped characters instead of a permanent hang.

Happy to provide the full evidence dossier (traces, before/after boot logs) on request.